### PR TITLE
Update processes to save output files under process name directory

### DIFF
--- a/pipeline/modules/joint-genotype-processes.nf
+++ b/pipeline/modules/joint-genotype-processes.nf
@@ -78,7 +78,7 @@ process run_SplitIntervals_GATK {
 
 process run_HaplotypeCaller_GATK {
     container params.docker_image_gatk
-    publishDir path:params.output_dir,
+    publishDir path: "${params.output_dir}/${task.process.replace(':', '/')}",
       mode: "copy",
       enabled: params.save_intermediate_files,
       pattern: '*.vcf*'
@@ -230,7 +230,7 @@ process run_SortVcf_GATK {
 process run_MergeVcfs_Picard {
     container params.docker_image_picard
 
-    publishDir path: params.output_dir,
+    publishDir path: "${params.output_dir}/${task.process.replace(':', '/')}",
       mode: "copy",
       enabled: params.save_intermediate_files,
       pattern: "*.vcf*"


### PR DESCRIPTION
Processes for call-gSNP updated to save output under process name directory. Future process updates for DSL2isation will follow the same structure for outputs.

Outputs for test runs here: 

- single sample: /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/single_dir_structure
- N-T paired: /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/paired_dir_structure

Resolves #2 