### PR TITLE
Parallelize MergeVcfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 - Update call-gSNP to DSL2
 - Add GPL2 license
+- Parallelize MergeVcfs


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/pages/viewpage.action?pageId=84091668).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the config as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and config file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline in single sample mode (at least one A-mini sample), N-T paired samples WGS mode, and N-T paired samples targeted exome mode. The paths to the test config files and output directories were attached below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Resolves #3 

Parallelizing MergeVcfs processes. There isn't really any time improvement since this process was very fast to begin with. I only tested on a paired WGS sample since that covers all of the changes made. The results match the non-parallelized version.

**Test Results**

- N-T paired WGS
	- samples:   TCEB1_RCC, S00-9422
	- input csv: /hot/users/yashpatel/pipeline-call-gSNP-DSL2/work/paired_test_input.csv
	- config:   /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/paired_wgs_parallel_mergevcfs/paired_wgs_parallel_mergevcfs.config 
	- output:	 /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/paired_wgs_parallel_mergevcfs
