### PR TITLE
Split HaplotypeCaller and adjust resource allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Standardize output and log directories
 - Add process to remove intermediate files when save_intermediate_files is disabled
 - Parallelize GetPileupSummaries, CalculateContamination, and DepthOfCoverage processes
+- Split HaplotypeCaller process into process for VCF and GVCF modes
+- Parallelize GVCF HC process
+- Adjust static resource allocation to be more efficient

--- a/pipeline/config/F72.config
+++ b/pipeline/config/F72.config
@@ -3,9 +3,13 @@ process {
         cpus = 1
         memory = 1.GB
     }
-    withName: run_HaplotypeCaller_GATK {
-        cpus = 6
-        memory = 15.GB
+    withName: run_HaplotypeCallerVCF_GATK {
+        cpus = 3
+        memory = 7.GB
+    }
+    withName: run_HaplotypeCallerGVCF_GATK {
+        cpus = 3
+        memory = 7.GB
     }
     withName: run_MergeVcfs_Picard {
         cpus = 1
@@ -13,11 +17,11 @@ process {
     }
     withName: run_RealignerTargetCreator_GATK {
         cpus = 6
-        memory = 15.GB
+        memory = 10.GB
     }
     withName: run_IndelRealigner_GATK {
         cpus = 6
-        memory = 15.GB
+        memory = 10.GB
     }
     withName: run_BaseRecalibrator_GATK {
         cpus = 1
@@ -25,11 +29,11 @@ process {
     }
     withName: run_ApplyBQSR_GATK {
         cpus = 1
-        memory = 15.GB
+        memory = 1.GB
     }
     withName: run_BuildBamIndex_Picard {
         cpus = 1
-        memory = 5.GB
+        memory = 1.GB
     }
     withName: run_MergeSamFiles_Picard {
         cpus = 1
@@ -45,7 +49,7 @@ process {
     }
     withName: run_DepthOfCoverage_GATK {
         cpus = 1
-        memory = 30.GB
+        memory = 10.GB
     }
     withName: remove_intermediate_files {
         cpus = 1

--- a/pipeline/config/M64.config
+++ b/pipeline/config/M64.config
@@ -3,21 +3,25 @@ process {
         cpus = 1
         memory = 1.GB
     }
-    withName: run_HaplotypeCaller_GATK {
-        cpus = 4
-        memory = 35.GB
+    withName: run_HaplotypeCallerVCF_GATK {
+        cpus = 3
+        memory = 7.GB
+    }
+    withName: run_HaplotypeCallerGVCF_GATK {
+        cpus = 3
+        memory = 7.GB
     }
     withName: run_MergeVcfs_Picard {
         cpus = 1
-        memory = 35.GB
+        memory = 15.GB
     }
     withName: run_RealignerTargetCreator_GATK {
         cpus = 4
-        memory = 35.GB
+        memory = 10.GB
     }
     withName: run_IndelRealigner_GATK {
         cpus = 4
-        memory = 35.GB
+        memory = 10.GB
     }
     withName: run_BaseRecalibrator_GATK {
         cpus = 1
@@ -25,11 +29,11 @@ process {
     }
     withName: run_ApplyBQSR_GATK {
         cpus = 1
-        memory = 35.GB
+        memory = 1.GB
     }
     withName: run_BuildBamIndex_Picard {
         cpus = 1
-        memory = 15.GB
+        memory = 1.GB
     }
     withName: run_MergeSamFiles_Picard {
         cpus = 1
@@ -37,15 +41,15 @@ process {
     }
     withName: run_GetPileupSummaries_GATK {
         cpus = 1
-        memory = 15.GB
+        memory = 5.GB
     }
     withName: run_CalculateContamination_GATK {
         cpus = 1
-        memory = 15.GB
+        memory = 5.GB
     }
     withName: run_DepthOfCoverage_GATK {
         cpus = 1
-        memory = 200.GB
+        memory = 10.GB
     }
     withName: remove_intermediate_files {
         cpus = 1

--- a/pipeline/config/methods.config
+++ b/pipeline/config/methods.config
@@ -86,8 +86,9 @@ methods {
 
   set_default_params = {
     // Default difference between task's allocated memory and heap memory
+    // Setting this to 0.GB as default but leaving it available as a param
     if(!params.gatk_command_mem_diff) {
-      params.gatk_command_mem_diff = 1.GB
+      params.gatk_command_mem_diff = 0.GB
     }
   }
 

--- a/pipeline/modules/genotype-processes.nf
+++ b/pipeline/modules/genotype-processes.nf
@@ -49,7 +49,7 @@ process run_SplitIntervals_GATK {
 }
 
 /*
-    Nextflow module for calling haplotypes
+    Nextflow module for calling haplotypes in VCF mode
 
     input:
         reference_fasta: path to reference genome fasta file
@@ -73,7 +73,7 @@ process run_SplitIntervals_GATK {
         params.is_NT_paired: bool. Indicator of whether input has normal and tumour samples
         params.gatk_command_mem_diff: float(memory)
 */
-process run_HaplotypeCaller_GATK {
+process run_HaplotypeCallerVCF_GATK {
     container params.docker_image_gatk
     publishDir path: "${params.output_dir}/intermediate/${task.process.replace(':', '/')}",
       mode: "copy",
@@ -100,25 +100,19 @@ process run_HaplotypeCaller_GATK {
 
 
     output:
-      path(".command.*")
-      path("${sample_id}_${task.index}.vcf"), emit: vcf
-      path("${sample_id}_${task.index}.vcf.idx"), emit: vcf_index
-      path("${normal_id}_${task.index}_raw_variants.g.vcf.gz"), emit: gvcf_normal
-      path("${normal_id}_${task.index}_raw_variants.g.vcf.gz.tbi"), emit: gvcf_normal_index
-      path("${tumour_id}_${task.index}_raw_variants.g.vcf.gz"), emit: gvcf_tumour optional true
-      path("${tumour_id}_${task.index}_raw_variants.g.vcf.gz.tbi"), emit: gvcf_tumour_index optional true
-      path(bam), emit: normal_bam_for_deletion
-      path(bam_index), emit: normal_bam_index_for_deletion
-      path(bam_tumour), emit: tumour_bam_for_deletion optional true
-      path(bam_index_tumour), emit: tumour_bam_index_for_deletion optional true
+    path(".command.*")
+    path("${sample_id}_${task.index}.vcf"), emit: vcf
+    path("${sample_id}_${task.index}.vcf.idx"), emit: vcf_index
+    path(bam), emit: normal_bam_for_deletion
+    path(bam_index), emit: normal_bam_index_for_deletion
+    path(bam_tumour), emit: tumour_bam_for_deletion optional true
+    path(bam_index_tumour), emit: tumour_bam_index_for_deletion optional true
 
     script:
-        out_filename_normal = "${normal_id}_${task.index}_raw_variants.g.vcf.gz"
-        out_filename_tumour = "${tumour_id}_${task.index}_raw_variants.g.vcf.gz"
-        out_filename_vcf = "${sample_id}_${task.index}.vcf"
-        interval_str = "--intervals ${interval}"
-        bam_input_str = params.is_NT_paired ? "--input ${bam} --input ${bam_tumour}" : "--input ${bam}"
-        interval_padding = params.is_targeted ? "--interval-padding 100" : ""
+    output_filename = "${sample_id}_${task.index}.vcf"
+    interval_str = "--intervals ${interval}"
+    bam_input_str = params.is_NT_paired ? "--input ${bam} --input ${bam_tumour}" : "--input ${bam}"
+    interval_padding = params.is_targeted ? "--interval-padding 100" : ""
 
     """
     set -euo pipefail
@@ -126,7 +120,7 @@ process run_HaplotypeCaller_GATK {
     gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=/scratch" \
         HaplotypeCaller \
         ${bam_input_str} \
-        --output ${out_filename_vcf} \
+        --output ${output_filename} \
         --reference ${reference_fasta} \
         --verbosity INFO \
         --output-mode EMIT_VARIANTS_ONLY \
@@ -135,11 +129,78 @@ process run_HaplotypeCaller_GATK {
         --standard-min-confidence-threshold-for-calling 50 \
         ${interval_str} \
         ${interval_padding}
+    """
+}
+
+
+/*
+    Nextflow module for calling haplotypes in GVCF mode
+
+    input:
+        reference_fasta: path to reference genome fasta file
+        reference_fasta_fai: path to index for reference fasta
+        reference_fasta_dict: path to dictionary for reference fasta
+        dbsnp_bundle: path to dbSNP variants
+        dbsnp_bundle_index: path to index of dbSNP variants
+        (sample_id, normal_id, tumour_id):  tuples of string identifiers for the samples
+        bam: path to BAM for calling
+        bam_index: path to index of BAM
+        interval: path to specific intervals for calling
+        sample_type: val to indicate whether processing normal or tumour sample
+        
+    params:
+        params.output_dir: string(path)
+        params.log_output_dir: string(path)
+        params.save_intermediate_files: bool.
+        params.docker_image_gatk: string
+        params.is_targeted: bool. Indicator of whether in targeted exome mode or in WGS mode
+        params.is_NT_paired: bool. Indicator of whether input has normal and tumour samples
+        params.gatk_command_mem_diff: float(memory)
+*/
+process run_HaplotypeCallerGVCF_GATK {
+    container params.docker_image_gatk
+    publishDir path: "${params.output_dir}/intermediate/${task.process.replace(':', '/')}",
+      mode: "copy",
+      enabled: params.save_intermediate_files,
+      pattern: '*.vcf*'
+
+    publishDir path: "${params.log_output_dir}/process-log",
+      pattern: ".command.*",
+      mode: "copy",
+      saveAs: { "${task.process.replace(':', '/')}/${task.process.replace(':', '/')}-${task.index}/log${file(it).getName()}" }
+
+    input:
+    path(reference_fasta)
+    path(reference_fasta_fai)
+    path(reference_fasta_dict)
+    path(dbsnp_bundle)
+    path(dbsnp_bundle_index)
+    tuple val(sample_id), val(normal_id), val(tumour_id)
+    path(bam)
+    path(bam_index)
+    path(interval)
+    val(sample_type)
+
+
+    output:
+    path(".command.*")
+    path("*_raw_variants.g.vcf.gz"), emit: gvcf
+    path("*_raw_variants.g.vcf.gz.tbi"), emit: gvcf_index
+    path(bam), emit: bam_for_deletion
+    path(bam_index), emit: bam_index_for_deletion
+
+    script:
+    output_filename = (sample_type == "normal") ? "${normal_id}_${task.index}_raw_variants.g.vcf.gz" : "${tumour_id}_${task.index}_raw_variants.g.vcf.gz"
+    interval_str = "--intervals ${interval}"
+    interval_padding = params.is_targeted ? "--interval-padding 100" : ""
+
+    """
+    set -euo pipefail
 
     gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=/scratch" \
         HaplotypeCaller \
         --input ${bam} \
-        --output ${out_filename_normal} \
+        --output ${output_filename} \
         --reference ${reference_fasta} \
         --verbosity INFO \
         --output-mode EMIT_VARIANTS_ONLY \
@@ -148,22 +209,6 @@ process run_HaplotypeCaller_GATK {
         --sample-ploidy 2 \
         ${interval_str} \
         ${interval_padding}
-
-    if ${params.is_NT_paired}
-    then
-      gatk --java-options "-Xmx${(task.memory - params.gatk_command_mem_diff).getMega()}m -DGATK_STACKTRACE_ON_USER_EXCEPTION=true -Djava.io.tmpdir=/scratch" \
-        HaplotypeCaller \
-        --input ${bam_tumour} \
-        --output ${out_filename_tumour} \
-        --reference ${reference_fasta} \
-        --verbosity INFO \
-        --output-mode EMIT_VARIANTS_ONLY \
-        --emit-ref-confidence GVCF \
-        --dbsnp ${dbsnp_bundle} \
-        --sample-ploidy 2 \
-        ${interval_str} \
-        ${interval_padding}
-    fi
     """
 }
 

--- a/pipeline/modules/intermediate-cleanup.nf
+++ b/pipeline/modules/intermediate-cleanup.nf
@@ -3,7 +3,9 @@
 
     input:
         file_to_remove: path to file to be removed
-        merge_sams_completion_signal: val to indicate that merge SAMs process has completed
+        ready_for_deletion_signal: val to indicate that the file can be removed. For example, 
+            if multiple processes need to use the file to be deleted, the signal allows for a
+            way to wait until all of those processes have completed before deleting the file.
 
     params:
         params.log_output_dir: string(path)
@@ -19,7 +21,7 @@ process remove_intermediate_files {
 
     input:
     path(file_to_remove)
-    val(merge_sams_completion_signal)
+    val(ready_for_deletion_signal)
 
     output:
     path(".command.*")


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/pages/viewpage.action?pageId=84091668).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the config as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and config file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline in single sample mode (at least one A-mini sample), N-T paired samples WGS mode, and N-T paired samples targeted exome mode. The paths to the test config files and output directories were attached below.

The HaplotypeCaller has been split into separate processes for VCF and GVCF modes, with the GVCF process being parallelized between normal and tumour samples. Also updated the static resource allocations based on usage seen during Tsumugi's large sample test. Overall, these changes cut the runtime down from approx. 4h50m to 3h17m, with no effect on the results.

Closes #4 

**Test Results**

- Single sample
	- sample:    A-mini-n1
	- input csv: /hot/users/yashpatel/pipeline-call-gSNP-DSL2/work/single_test_input.csv
	- config:    /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/single_HC_split/single_HC_split.config
	- output:    /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/single_HC_split
- N-T paired WGS - with intermediate files - 3h17m
	- samples:   S00-9422
	- input csv: /hot/users/yashpatel/pipeline-call-gSNP-DSL2/work/paired_test_input.csv
	- config:    /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/paired_wgs_HC_split/paired_wgs_HC_split.config
	- output:	 /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/paired_wgs_HC_split
- N-T paired WGS - no intermediate files - 3h17m
	- samples:   S00-9422
	- input csv: /hot/users/yashpatel/pipeline-call-gSNP-DSL2/work/paired_test_input.csv
	- config:    /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/paired_wgs_HC_split_nointermediate/paired_wgs_HC_split_nointermediate.config
	- output:	 /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/paired_wgs_HC_split_nointermediate