### PR TITLE
Fix BAM index names and auto-detect the fasta dict file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,4 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Parallelize GetPileupSummaries, CalculateContamination, and DepthOfCoverage processes
 - Split HaplotypeCaller process into process for VCF and GVCF modes
 - Parallelize GVCF HC process
+
+### Changed
 - Adjust static resource allocation to be more efficient
+- Auto-detect reference fasta dictionary
+- Rename ".bai" output files to ".bam.bai"

--- a/pipeline/call-gSNP.nf
+++ b/pipeline/call-gSNP.nf
@@ -124,7 +124,7 @@ workflow {
       intervals,
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict"
     )
 
     split_intervals = run_SplitIntervals_GATK.out.interval_list.flatten()
@@ -238,7 +238,7 @@ workflow {
     run_DepthOfCoverage_GATK_normal(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       split_intervals.collect(),
       run_MergeSamFiles_Picard_normal.out.merged_bam,
       run_MergeSamFiles_Picard_normal.out.merged_bam_index,
@@ -250,7 +250,7 @@ workflow {
       run_DepthOfCoverage_GATK_tumour(
         params.reference_fasta,
         "${params.reference_fasta}.fai",
-        params.reference_dict,
+        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
         split_intervals.collect(),
         merged_tumour_bam,
         merged_tumour_bam_index,
@@ -270,7 +270,7 @@ workflow {
     run_HaplotypeCallerVCF_GATK(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       params.bundle_v0_dbsnp138_vcf_gz,
       "${params.bundle_v0_dbsnp138_vcf_gz}.tbi",
       hc_identifiers,
@@ -284,7 +284,7 @@ workflow {
     run_HaplotypeCallerGVCF_GATK_normal(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       params.bundle_v0_dbsnp138_vcf_gz,
       "${params.bundle_v0_dbsnp138_vcf_gz}.tbi",
       hc_identifiers,
@@ -298,7 +298,7 @@ workflow {
       run_HaplotypeCallerGVCF_GATK_tumour(
         params.reference_fasta,
         "${params.reference_fasta}.fai",
-        params.reference_dict,
+        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
         params.bundle_v0_dbsnp138_vcf_gz,
         "${params.bundle_v0_dbsnp138_vcf_gz}.tbi",
         hc_identifiers,
@@ -375,7 +375,7 @@ workflow {
     filter_gSNP_GATK(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       recalibrate_indels.out.vcf,
       recalibrate_indels.out.vcf_index,
       filter_gSNP_identifiers

--- a/pipeline/config/call-gSNP.config
+++ b/pipeline/config/call-gSNP.config
@@ -41,7 +41,6 @@ params {
     // GATK requires the reference fasta to be accompanied by a .fai index and .dict dictionary associated with the fasta for fast random access
     // These can be found in the same folder as the reference here: /hot/ref/reference/GRCh38-BI-20160721
     reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
-    reference_dict = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.dict"
 
     // GATK bundle - Used here hg38 decoy version
     bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"

--- a/pipeline/modules/bam-processing.nf
+++ b/pipeline/modules/bam-processing.nf
@@ -137,7 +137,8 @@ process run_MergeSamFiles_Picard {
     container params.docker_image_picard
     publishDir path: "${params.output_dir}/output",
         mode: "copy",
-        pattern: "*_merged*"
+        pattern: "*_merged*",
+        saveAs: { filename -> (file(filename).getExtension() == "bai") ? "${file(filename).baseName}.bam.bai" : "${filename}" }
 
     publishDir path: "${params.log_output_dir}/process-log",
         pattern: ".command.*",

--- a/pipeline/modules/base-recalibration.nf
+++ b/pipeline/modules/base-recalibration.nf
@@ -102,7 +102,8 @@ process run_ApplyBQSR_GATK {
     publishDir path: "${params.output_dir}/intermediate/${task.process.replace(':', '/')}",
       mode: "copy",
       enabled: params.save_intermediate_files,
-      pattern: "*_recalibrated_*"
+      pattern: "*_recalibrated_*",
+      saveAs: { filename -> (file(filename).getExtension() == "bai") ? "${file(filename).baseName}.bam.bai" : "${filename}" }
 
     publishDir path: "${params.log_output_dir}/process-log",
       pattern: ".command.*",
@@ -174,7 +175,7 @@ workflow recalibrate_base {
     run_BaseRecalibrator_GATK(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz,
       "${params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi",
       params.bundle_known_indels_vcf_gz,
@@ -190,7 +191,7 @@ workflow recalibrate_base {
     run_ApplyBQSR_GATK(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       run_BaseRecalibrator_GATK.out.recalibration_table,
       realigned_bam,
       realigned_bam_index,

--- a/pipeline/modules/indel-realignment.nf
+++ b/pipeline/modules/indel-realignment.nf
@@ -98,7 +98,8 @@ process run_IndelRealigner_GATK {
     publishDir path: "${params.output_dir}/intermediate/${task.process.replace(':', '/')}",
       mode: "copy",
       enabled: params.save_intermediate_files,
-      pattern: "*_indelrealigned_*"
+      pattern: "*_indelrealigned_*",
+      saveAs: { filename -> (file(filename).getExtension() == "bai") ? "${file(filename).baseName}.bam.bai" : "${filename}" }
 
     publishDir path: "${params.log_output_dir}/process-log",
       pattern: ".command.*",
@@ -155,7 +156,7 @@ workflow realign_indels {
     run_RealignerTargetCreator_GATK(
         params.reference_fasta,
         "${params.reference_fasta}.fai",
-        params.reference_dict,
+        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
         params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz,
         "${params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi",
         params.bundle_known_indels_vcf_gz,
@@ -166,7 +167,7 @@ workflow realign_indels {
     run_IndelRealigner_GATK(
         params.reference_fasta,
         "${params.reference_fasta}.fai",
-        params.reference_dict,
+        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
         params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz,
         "${params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi",
         params.bundle_known_indels_vcf_gz,

--- a/pipeline/modules/summary-processes.nf
+++ b/pipeline/modules/summary-processes.nf
@@ -202,7 +202,7 @@ workflow calculate_contamination_normal {
     run_GetPileupSummaries_GATK(
         params.reference_fasta,
         "${params.reference_fasta}.fai",
-        params.reference_dict,
+        "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
         params.bundle_contest_hapmap_3p3_vcf_gz,
         "${params.bundle_contest_hapmap_3p3_vcf_gz}.tbi",
         all_intervals.collect(),

--- a/pipeline/modules/validation.nf
+++ b/pipeline/modules/validation.nf
@@ -44,7 +44,8 @@ process calculate_sha512 {
     container params.docker_image_validate
     publishDir path: "${params.output_dir}/output",
       mode: "copy",
-      pattern: "*.sha512"
+      pattern: "*.sha512",
+      saveAs: { filename -> (filename.endsWith(".bai.sha512") && !filename.endsWith(".bam.bai.sha512")) ? "${file(file(filename).baseName).baseName}.bam.bai.sha512" : "${filename}"}
 
     publishDir path: "${params.log_output_dir}/process-log",
       pattern: ".command.*",

--- a/pipeline/modules/variant-recalibration.nf
+++ b/pipeline/modules/variant-recalibration.nf
@@ -342,7 +342,7 @@ workflow recalibrate_snps {
   run_VariantRecalibratorSNP_GATK(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       params.bundle_v0_dbsnp138_vcf_gz,
       "${params.bundle_v0_dbsnp138_vcf_gz}.tbi",
       params.bundle_hapmap_3p3_vcf_gz,
@@ -361,7 +361,7 @@ workflow recalibrate_snps {
       'SNP',
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       run_VariantRecalibratorSNP_GATK.out.snp_recal
   )
 
@@ -380,7 +380,7 @@ workflow recalibrate_indels {
   run_VariantRecalibratorINDEL_GATK(
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz,
       "${params.bundle_mills_and_1000g_gold_standard_indels_vcf_gz}.tbi",
       merge_identifiers,
@@ -393,7 +393,7 @@ workflow recalibrate_indels {
       'SNP_AND_INDEL',
       params.reference_fasta,
       "${params.reference_fasta}.fai",
-      params.reference_dict,
+      "${file(params.reference_fasta).parent}/${file(params.reference_fasta).baseName}.dict",
       run_VariantRecalibratorINDEL_GATK.out.indel_recal
   )
 


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/pages/viewpage.action?pageId=84091668).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the config as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and config file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [X] I have tested the pipeline in single sample mode (at least one A-mini sample), N-T paired samples WGS mode, and N-T paired samples targeted exome mode. The paths to the test config files and output directories were attached below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Manually modifying the names of the automatically generated BAM index files to contain `.bam` and moving the detection of the reference fasta dictionary into the pipeline. 

Closes #33 

**Test Results**

- Single sample
	- sample:    A-mini-n1
	- input csv: /hot/users/yashpatel/pipeline-call-gSNP-DSL2/work/single_test_input.csv
	- config:    /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/single_index_dict_fix/single_index_dict_fix.config
	- output:    /hot/pipelines/development/slurm/call-gSNP/DSL2_outputs/single_index_dict_fix