### PR TITLE
Save VQSR model output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Use sample ID and intervals as identifiers for log output directories
 - Standardize config structure
 - Partially revert BQSR parallelization and group ApplyBQSR by interval
+- Save VQSR output for QC
 
 ---
 

--- a/pipeline/modules/variant-recalibration.nf
+++ b/pipeline/modules/variant-recalibration.nf
@@ -23,7 +23,12 @@ process run_VariantRecalibratorINDEL_GATK {
     publishDir path: "${params.output_dir}/intermediate/${task.process.replace(':', '/')}",
       mode: "copy",
       enabled: params.save_intermediate_files,
-      pattern: "*_output_indel.*"
+      pattern: "*_output_indel.{recal*,tranches}"
+
+    publishDir path: "${params.output_dir}/QC/${task.process.replace(':', '/')}",
+      mode: "copy",
+      enabled: params.save_intermediate_files,
+      pattern: "*_output_indel.{plots*}"
 
     publishDir path: "${params.log_output_dir}/process-log",
       pattern: ".command.*",
@@ -107,7 +112,12 @@ process run_VariantRecalibratorSNP_GATK {
     publishDir path: "${params.output_dir}/intermediate/${task.process.replace(':', '/')}",
       mode: "copy",
       enabled: params.save_intermediate_files,
-      pattern: "*_output_snp.*"
+      pattern: "*_output_snp.{recal*,tranches}"
+
+    publishDir path: "${params.output_dir}/QC/${task.process.replace(':', '/')}",
+      mode: "copy",
+      enabled: params.save_intermediate_files,
+      pattern: "*_output_snp.{plots*,tranches.pdf}"
 
     publishDir path: "${params.log_output_dir}/process-log",
       pattern: ".command.*",
@@ -135,6 +145,7 @@ process run_VariantRecalibratorSNP_GATK {
     path(".command.*")
     path("${sample_id}_output_snp.plots.R")
     path("${sample_id}_output_snp.plots.R.pdf")
+    path("${sample_id}_output_snp.tranches.pdf")
     tuple path(sample_vcf),
           path(sample_vcf_tbi),
           path("${sample_id}_output_snp.recal"),


### PR DESCRIPTION
<!--- Please read each of the following items and confirm by replacing
 !--the [ ] with a [X] --->

- [X] I have read the [code review guidelines](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Guidelines) and the [code review best practice on GitHub check-list](https://confluence.mednet.ucla.edu/pages/viewpage.action?pageId=84091668).

- [X] The name of the branch is meaningful and well formatted following the [standards](https://confluence.mednet.ucla.edu/display/BOUTROSLAB/Code+Review+Best+Practice+on+GitHub+-+Check+List), using \[AD_username (or 5 letters of AD if AD is too long)-\[brief_description_of_branch].

- [X] I have set up the branch protection rule following the [github standards](https://confluence.mednet.ucla.edu/pages/viewpage.action?spaceKey=BOUTROSLAB&title=GitHub+Standards#GitHubStandards-Branchprotectionrule) before opening this pull request, or the branch protection rule has already been set up.

- [X] I have added my name to the contributors listings in the
``metadata.yaml`` and the ``manifest`` block in the config as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)

- [X] I have added the changes included in this pull request to the `CHANGELOG.md` under the next release version or unreleased, and updated the date.

- [ ] I have updated the version number in the `metadata.yaml` and config file following [semver](https://semver.org/), or the version number has already been updated. (*Leave it unchecked if you are unsure about new version number and discuss it with the infrastructure team in this PR.*)

- [ ] I have tested the pipeline in single sample mode (at least one A-mini sample), N-T paired samples WGS mode, and N-T paired samples targeted exome mode. The paths to the test config files and output directories were attached below.

<!--- Briefly describe the changes included in this pull request and the paths to the test cases below
 !--- starting with 'Closes #...' if appropriate --->

Saving the model of VQSR into intermediate and QC output directories. In indel mode, the process doesn't produce the `*.tranches.pdf` file.

**Test Results**

- Single WGS
	- sample:    A-mini-n1
	- input csv: /hot/users/yashpatel/pipeline-call-gSNP/work/single_test_input.csv
	- config:    /hot/pipeline/development/slurm/call-gSNP/unreleased/yashpatel-save-vqsr-tranches/single_wgs/single_wgs.config
	- output:    /hot/pipeline/development/slurm/call-gSNP/unreleased/yashpatel-save-vqsr-tranches/single_wgs
- N-T targeted
	- samples:   S00-9422
	- input csv: /hot/users/yashpatel/pipeline-call-gSNP/work/paired_test_input.csv
	- config:    /hot/pipeline/development/slurm/call-gSNP/unreleased/yashpatel-save-vqsr-tranches/paired_targeted/paired_targeted.config
	- output:	 /hot/pipeline/development/slurm/call-gSNP/unreleased/yashpatel-save-vqsr-tranches/paired_targeted
