### PR TITLE
Update dependabot to group common submodules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
+---
 version: 2
 updates:
-  - package-ecosystem: "gitsubmodule" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "gitsubmodule"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      # Group these two modules together for pull requests
+      # "pipeline-submodules" is an arbitrary name
+      pipeline-submodules:
+        patterns:
+          - "*/pipeline-Nextflow-config"
+          - "*/pipeline-Nextflow-module"


### PR DESCRIPTION
# Description
This updates the [dependabot](https://github.com/dependabot) configuration to group updates for pipeline-Nextflow-config and pipeline-Nextflow-module into a single PR. That should greatly reduce the testing burden to keep the submodules up-to-date.

See https://github.com/uclahs-cds/pipeline-recalibrate-BAM/pull/79 (and the resulting https://github.com/uclahs-cds/pipeline-recalibrate-BAM/pull/80) for an example of this configuration working.
