### PR TITLE
Update cluster reference paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ For normal-only or tumor-only samples, exclude the fields for the other state.
 | `cache_intermediate_pipeline_steps` | No | boolean | Set to true to enable process caching from Nextflow; defaults to false |
 | `scatter_count` | Yes | integer | Number of intervals to divide into for parallelization |
 | `intervals` | Yes | path | Use all .list in inputs for WGS; Set to absolute path to targeted exome interval file (with .interval_list, .list, .intervals, or .bed suffix) |
-| `reference_fasta` | Yes | path | Absolute path to reference genome fasta file, e.g., `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` |
-| `bundle_mills_and_1000g_gold_standard_indels_vcf_gz` | Yes | path | Absolute path to Mills & 1000G Gold Standard Indels file, e.g., `/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz` |
-| `bundle_v0_dbsnp138_vcf_gz` | Yes | path | Absolute path to dbsnp file, e.g., `/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz` |
-| `bundle_hapmap_3p3_vcf_gz` | Yes | path | Absolute path to HapMap 3.3 file, e.g., `/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz` |
-| `bundle_omni_1000g_2p5_vcf_gz` | Yes | path | Absolute path to 1000 genomes OMNI 2.5 file, e.g., `/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz` |
-| `bundle_phase1_1000g_snps_high_conf_vcf_gz` | Yes | path | Absolute path to 1000 genomes phase 1 high-confidence file, e.g., `/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz` |
+| `reference_fasta` | Yes | path | Absolute path to reference genome fasta file, e.g., `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta` |
+| `bundle_mills_and_1000g_gold_standard_indels_vcf_gz` | Yes | path | Absolute path to Mills & 1000G Gold Standard Indels file, e.g., `/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz` |
+| `bundle_v0_dbsnp138_vcf_gz` | Yes | path | Absolute path to dbsnp file, e.g., `/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz` |
+| `bundle_hapmap_3p3_vcf_gz` | Yes | path | Absolute path to HapMap 3.3 file, e.g., `/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz` |
+| `bundle_omni_1000g_2p5_vcf_gz` | Yes | path | Absolute path to 1000 genomes OMNI 2.5 file, e.g., `/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz` |
+| `bundle_phase1_1000g_snps_high_conf_vcf_gz` | Yes | path | Absolute path to 1000 genomes phase 1 high-confidence file, e.g., `/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz` |
 | `work_dir` | optional | path | Path of working directory for Nextflow. When included in the sample config file, Nextflow intermediate files and logs will be saved to this directory. With ucla_cds, the default is `/scratch` and should only be changed for testing/development. Changing this directory to `/hot` or `/tmp` can lead to high server latency and potential disk space limitations, respectively. |
 | `docker_container_registry` | optional | string | Registry containing tool Docker images. Default: `ghcr.io/uclahs-cds` |
 | `base_resource_update` | optional | namespace | Namespace of parameters to update base resource allocations in the pipeline. Usage and structure are detailed in `template.config` and below. |

--- a/config/template.config
+++ b/config/template.config
@@ -33,15 +33,15 @@ params {
 
     // Reference - Used here hg38 decoy version
     // GATK requires the reference fasta to be accompanied by a .fai index and .dict dictionary associated with the fasta for fast random access
-    // These can be found in the same folder as the reference here: /hot/ref/reference/GRCh38-BI-20160721
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    // These can be found in the same folder as the reference here: /hot/resource/reference-genome/GRCh38-BI-20160721
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
     // GATK bundle - Used here hg38 decoy version
-    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-    bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-    bundle_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
-    bundle_omni_1000g_2p5_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
-    bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+    bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+    bundle_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
+    bundle_omni_1000g_2p5_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
+    bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
 
     // Base resource allocation updater
     // See README for adding parameters to update the base resource allocations

--- a/test/test-call-gSNP-paired.config
+++ b/test/test-call-gSNP-paired.config
@@ -31,15 +31,15 @@ params {
 
     // Reference - Used here hg38 decoy version
     // GATK requires the reference fasta to be accompanied by a .fai index and .dict dictionary associated with the fasta for fast random access
-    // These can be found in the same folder as the reference here: /hot/ref/reference/GRCh38-BI-20160721
-    reference_fasta = "/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
+    // These can be found in the same folder as the reference here: /hot/resource/reference-genome/GRCh38-BI-20160721
+    reference_fasta = "/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta"
 
     // GATK bundle - Used here hg38 decoy version
-    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
-    bundle_v0_dbsnp138_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
-    bundle_hapmap_3p3_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
-    bundle_omni_1000g_2p5_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
-    bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
+    bundle_mills_and_1000g_gold_standard_indels_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz"
+    bundle_v0_dbsnp138_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz"
+    bundle_hapmap_3p3_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz"
+    bundle_omni_1000g_2p5_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz"
+    bundle_phase1_1000g_snps_high_conf_vcf_gz = "/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz"
 
     // Base resource allocation updater
     // See README for adding parameters to update the base resource allocations


### PR DESCRIPTION
This PR updates reference paths that were renamed during the most recent cluster downtime.

I was specifically looking for single lines containing one (or more) of the following keys, so I missed any paths split across multiple lines.

| Search String                                                  |
|----------------------------------------------------------------|
| `/hot/ref/`                                                    |
| `/hot/ref/cohort/TCGA/CCG-AIM/`                                |
| `/hot/ref/cohort/TCGA/PanCanAtlas/`                            |
| `/hot/ref/database/1000Genomes/`                               |
| `/hot/ref/database/GDC-34.0 `                                  |
| `/hot/ref/database/GDC-34.0/`                                  |
| `/hot/ref/database/PCAWG/`                                     |
| `/hot/ref/database/ProstateTumor/Boutros-Yamaguchi-PRAD-CPCG/` |
| `/hot/ref/reference/`                                          |
| `/hot/resource/SMC-HET/`                                       |

A table of updated filepaths and whether or not they resolve to a file is included below. Where the original paths still exist due to symlinks I verified that they resolve to the same file as the updated path.

| Original                                                                                                   |                    | Updated                                                                                                         |                    |
|------------------------------------------------------------------------------------------------------------|--------------------|-----------------------------------------------------------------------------------------------------------------|--------------------|
| `/hot/ref/reference/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                                      | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721/Homo_sapiens_assembly38.fasta`                               | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz`                | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz`                | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz` | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/resources_broad_hg38_v0_Homo_sapiens_assembly38.dbsnp138.vcf.gz` | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz`                                          | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/hapmap_3.3.hg38.vcf.gz`                                          | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz`                                       | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/1000G_omni2.5.hg38.vcf.gz`                                       | :white_check_mark: |
| `/hot/ref/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz`                   | :white_check_mark: | `/hot/resource/tool-specific-input/GATK/GRCh38/1000G_phase1.snps.high_confidence.hg38.vcf.gz`                   | :white_check_mark: |
| `/hot/ref/reference/GRCh38-BI-20160721`                                                                    | :white_check_mark: | `/hot/resource/reference-genome/GRCh38-BI-20160721`                                                             | :white_check_mark: |