### PR TITLE
Add nextflow.config to release management process

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -29,4 +29,5 @@ jobs:
     with:
       bump_type: ${{ inputs.bump_type }}
       prerelease: ${{ inputs.prerelease }}
+      version_files: nextflow.config
     secrets: inherit


### PR DESCRIPTION
The PR I made previously to manage the release process neglected a very important part - updating the embedded version number!

All this PR does is register the `nextflow.config` file with the action to ensure that it is updated when new releases are created.
